### PR TITLE
Creation Reporting Layer

### DIFF
--- a/starbucks_dw/dbt_project.yml
+++ b/starbucks_dw/dbt_project.yml
@@ -21,6 +21,8 @@ models:
       +schema: staging
     marts:
       +schema: marts
+    reporting:
+      +schema: reporting
 
 seeds:
   +schema: raw

--- a/starbucks_dw/macros/calculate_response_rate.sql
+++ b/starbucks_dw/macros/calculate_response_rate.sql
@@ -1,0 +1,10 @@
+{% macro calculate_response_rate(column_name, statuses, total_count_column, alias) %}
+    ROUND(
+        (COUNT(CASE WHEN {{ column_name }} IN (
+            {%- for status in statuses -%}
+                '{{ status }}'{% if not loop.last %}, {% endif %}
+            {%- endfor -%}
+        ) THEN 1 END) * 1.0) / 
+        COUNT({{ total_count_column }}),
+    4) AS {{ alias }}
+{% endmacro %}

--- a/starbucks_dw/macros/count_transactions.sql
+++ b/starbucks_dw/macros/count_transactions.sql
@@ -1,0 +1,7 @@
+{% macro count_transactions(column_name, statuses, alias) %}
+    COUNT(CASE WHEN {{ column_name }} IN (
+        {%- for status in statuses -%}
+            '{{ status }}'{% if not loop.last %}, {% endif %}
+        {%- endfor -%}
+    ) THEN 1 END) AS {{ alias }}
+{% endmacro %}

--- a/starbucks_dw/macros/format_transaction_type.sql
+++ b/starbucks_dw/macros/format_transaction_type.sql
@@ -7,4 +7,3 @@
         ELSE NULL
     END
 {% endmacro %}
-

--- a/starbucks_dw/macros/format_transaction_type.sql
+++ b/starbucks_dw/macros/format_transaction_type.sql
@@ -1,0 +1,10 @@
+{% macro format_transaction_type(column_name) %}
+    CASE
+        WHEN {{ column_name }} = 'offer received' THEN 'received'
+        WHEN {{ column_name }} = 'offer viewed' THEN 'viewed'
+        WHEN {{ column_name }} = 'offer completed' THEN 'completed'
+        WHEN {{ column_name }} = 'transaction' THEN 'transaction'
+        ELSE NULL
+    END
+{% endmacro %}
+

--- a/starbucks_dw/macros/schema.yml
+++ b/starbucks_dw/macros/schema.yml
@@ -10,11 +10,10 @@ macros:
 
   - name: format_transaction_type
     description: >
-      This macro uses Jinja to dynamically format values in the transaction_type column. 
+      This macro uses Jinja to dynamically format values in the transaction_type column.
       It converts values such as 'offer received', 'offer viewed', etc., into simplified states:
       'received', 'viewed', 'completed', or 'transaction'.
     arguments:
       - name: column_name
         description: Name of the SQL column (table.column) containing the transaction_type values.
         type: text
-

--- a/starbucks_dw/macros/schema.yml
+++ b/starbucks_dw/macros/schema.yml
@@ -17,3 +17,41 @@ macros:
       - name: column_name
         description: Name of the SQL column (table.column) containing the transaction_type values.
         type: text
+
+  - name: count_transactions
+    description: >
+      This macro counts the number of transactions types per offer status. 
+      Returns a `COUNT` aggregate expression.
+    arguments:
+      - name: column_name
+        description: The column to evaluate transaction types.
+        type: string
+      - name: statuses
+        description: >
+          A list of statuses to check for in the `column_name`. Transactions 
+          with these statuses will be counted.
+        type: list
+      - name: alias
+        description: The alias name for the resulting column.
+        type: string
+
+  - name: calculate_response_rate
+    description: >
+      This macro calculates the response rate for specific offer statuses. 
+      It divides the count of matching transaction types by the total count of a given column.
+    arguments:
+      - name: column_name
+        description: The column to evaluate transaction types.
+        type: string
+      - name: statuses
+        description: >
+          A list of statuses to check for in the `column_name`. Transactions 
+          with these statuses will be included in the numerator of the calculation.
+        type: list
+      - name: total_count_column
+        description: >
+          The column used as the denominator for the status response rate calculation.
+        type: string
+      - name: alias
+        description: The alias name for the resulting status response rate column.
+        type: string

--- a/starbucks_dw/macros/schema.yml
+++ b/starbucks_dw/macros/schema.yml
@@ -7,3 +7,14 @@ macros:
       - name: hours
         description: Number of hours.
         type: integer
+
+  - name: format_transaction_type
+    description: >
+      This macro uses Jinja to dynamically format values in the transaction_type column. 
+      It converts values such as 'offer received', 'offer viewed', etc., into simplified states:
+      'received', 'viewed', 'completed', or 'transaction'.
+    arguments:
+      - name: column_name
+        description: Name of the SQL column (table.column) containing the transaction_type values.
+        type: text
+

--- a/starbucks_dw/models/marts/dim_customer.sql
+++ b/starbucks_dw/models/marts/dim_customer.sql
@@ -1,8 +1,8 @@
-{# {{
+{{
   config(
     materialized = 'table',
     )
 }}
 
 select *
-from {{ ref('stg_profile') }} #}
+from {{ ref('stg_profile') }}

--- a/starbucks_dw/models/marts/dim_date.sql
+++ b/starbucks_dw/models/marts/dim_date.sql
@@ -1,4 +1,8 @@
-/* TO BE IMPLEMENTED BY THE STUDENT */
-select 1
-union all
-select 2
+{{ 
+    config(
+        materialized='table'
+    ) 
+}}
+
+{{ dbt_date.get_date_dimension("2015-01-01", "2050-12-31") }}
+

--- a/starbucks_dw/models/marts/dim_date.sql
+++ b/starbucks_dw/models/marts/dim_date.sql
@@ -1,8 +1,7 @@
-{{ 
+{{
     config(
         materialized='table'
-    ) 
+    )
 }}
 
 {{ dbt_date.get_date_dimension("2015-01-01", "2050-12-31") }}
-

--- a/starbucks_dw/models/marts/fct_customer_transactions.sql
+++ b/starbucks_dw/models/marts/fct_customer_transactions.sql
@@ -1,4 +1,4 @@
-{# {{
+{{
   config(
     materialized = 'table',
     )
@@ -49,4 +49,4 @@ with
     )
 
 select *
-from final #}
+from final

--- a/starbucks_dw/models/marts/fct_customer_transactions.sql
+++ b/starbucks_dw/models/marts/fct_customer_transactions.sql
@@ -32,16 +32,7 @@ with
             customers.gender,
             customers.age,
             customers.income,
-            case
-                when transactions.transaction_type = 'offer received'
-                then 'received'
-                when transactions.transaction_type = 'offer viewed'
-                then 'viewed'
-                when transactions.transaction_type = 'offer completed'
-                then 'completed'
-                when transactions.transaction_type = 'transaction'
-                then 'transaction'
-            end as transaction_status,
+            {{ format_transaction_type('transactions.transaction_type') }} AS transaction_type,
             customers.subscribed_date as customer_subscribed_date,
             current_timestamp as ingested_at
         from transactions

--- a/starbucks_dw/models/marts/fct_offer_transactions.sql
+++ b/starbucks_dw/models/marts/fct_offer_transactions.sql
@@ -39,16 +39,7 @@ with
             offers.difficulty_rank as offer_difficulty_rank,
             offers.duration as offer_duration,
             transactions.reward as offer_reward,
-            case
-                when transactions.transaction_type = 'offer received'
-                then 'received'
-                when transactions.transaction_type = 'offer viewed'
-                then 'viewed'
-                when transactions.transaction_type = 'offer completed'
-                then 'completed'
-                when transactions.transaction_type = 'transaction'
-                then 'transaction'
-            end as transaction_status,
+            {{ format_transaction_type('transactions.transaction_type') }} AS transaction_type,
             transactions.hours_since_start,
             transactions.days_since_start,
             current_timestamp as ingested_at

--- a/starbucks_dw/models/marts/schema.yml
+++ b/starbucks_dw/models/marts/schema.yml
@@ -228,7 +228,7 @@ models:
         data_type: numeric
         data_tests:
           - not_null
-      - name: transaction_status
+      - name: transaction_type
         description: Status of the transaction.
         data_type: text
         data_tests:
@@ -299,7 +299,7 @@ models:
         data_type: numeric
         data_tests:
           - not_null
-      - name: transaction_status
+      - name: transaction_type
         description: Status of the transaction.
         data_type: text
         data_tests:

--- a/starbucks_dw/models/marts/schema.yml
+++ b/starbucks_dw/models/marts/schema.yml
@@ -255,7 +255,7 @@ models:
         data_tests:
           - not_null
 
-  - name: fact_customer_transactions
+  - name: fct_customer_transactions
     description: >
       Fact table about the customer transactions through the promotional offers program.
     columns:

--- a/starbucks_dw/models/reporting/channels_response_rate.sql
+++ b/starbucks_dw/models/reporting/channels_response_rate.sql
@@ -1,0 +1,22 @@
+{{
+  config(
+    materialized = 'table'
+  )
+}}
+
+
+select
+    o.channel AS offer_channel,
+    o.offer_type AS offer_type,
+    o.difficulty_rank AS difficulty_rank,
+    round((COUNT(CASE WHEN f.transaction_type IN ('completed', 'transaction') THEN 1 END) * 1.0) / COUNT(f.transaction_id),4) AS completed_response_rate,
+    round((COUNT(CASE WHEN f.transaction_type IN ('viewed', 'transaction') THEN 1 END) * 1.0) / COUNT(f.transaction_id),4) AS viewed_response_rate,
+    round((COUNT(CASE WHEN f.transaction_type IN ('received', 'transaction') THEN 1 END) * 1.0) / COUNT(f.transaction_id),4) AS received_response_rate,
+    COUNT(CASE WHEN f.transaction_type IN ('completed', 'transaction') THEN 1 END) AS completed_status_transactions,
+    COUNT(CASE WHEN f.transaction_type IN ('viewed', 'transaction') THEN 1 END) AS viewed_status_transactions,
+    COUNT(CASE WHEN f.transaction_type IN ('received', 'transaction') THEN 1 END) AS received_status_transactions,
+    COUNT(f.transaction_id) AS total_transactions
+from {{ ref('fct_offer_transactions') }} f
+inner join {{ ref('dim_offer') }} o on f.offer_id = o.offer_id
+where f.transaction_type in ('received', 'viewed', 'completed', 'transaction')
+group by o.channel,o.offer_type,o.difficulty_rank

--- a/starbucks_dw/models/reporting/channels_response_rate.sql
+++ b/starbucks_dw/models/reporting/channels_response_rate.sql
@@ -8,10 +8,12 @@
 select
     o.channel AS offer_channel,
     o.offer_type AS offer_type,
-    o.difficulty_rank AS difficulty_rank,
-    round((COUNT(CASE WHEN f.transaction_type IN ('completed', 'transaction') THEN 1 END) * 1.0) / COUNT(f.transaction_id),4) AS completed_response_rate,
-    round((COUNT(CASE WHEN f.transaction_type IN ('viewed', 'transaction') THEN 1 END) * 1.0) / COUNT(f.transaction_id),4) AS viewed_response_rate,
-    round((COUNT(CASE WHEN f.transaction_type IN ('received', 'transaction') THEN 1 END) * 1.0) / COUNT(f.transaction_id),4) AS received_response_rate,
+    o.difficulty_rank AS difficulty_rank, -- It will influence the number of transactions with complete status
+    -- Calculating response rates per status of offer transaction
+    ROUND((COUNT(CASE WHEN f.transaction_type IN ('completed', 'transaction') THEN 1 END) * 1.0) / COUNT(f.transaction_id),4) AS completed_response_rate,
+    ROUND((COUNT(CASE WHEN f.transaction_type IN ('viewed', 'transaction') THEN 1 END) * 1.0) / COUNT(f.transaction_id),4) AS viewed_response_rate,
+    ROUND((COUNT(CASE WHEN f.transaction_type IN ('received', 'transaction') THEN 1 END) * 1.0) / COUNT(f.transaction_id),4) AS received_response_rate,
+    -- Sum of offer transactions per status and total offer transactions
     COUNT(CASE WHEN f.transaction_type IN ('completed', 'transaction') THEN 1 END) AS completed_status_transactions,
     COUNT(CASE WHEN f.transaction_type IN ('viewed', 'transaction') THEN 1 END) AS viewed_status_transactions,
     COUNT(CASE WHEN f.transaction_type IN ('received', 'transaction') THEN 1 END) AS received_status_transactions,

--- a/starbucks_dw/models/reporting/cust_segment_response.sql
+++ b/starbucks_dw/models/reporting/cust_segment_response.sql
@@ -1,0 +1,87 @@
+{{
+  config(
+    materialized = 'table'
+  )
+}}
+
+
+WITH age_buckets AS (
+    SELECT
+        customer_id,
+        CASE 
+            WHEN age < 18 THEN 'Under 18'
+            WHEN age BETWEEN 18 AND 24 THEN '18-24'
+            WHEN age BETWEEN 25 AND 34 THEN '25-34'
+            WHEN age BETWEEN 35 AND 44 THEN '35-44'
+            WHEN age BETWEEN 45 AND 54 THEN '45-54'
+            WHEN age BETWEEN 55 AND 64 THEN '55-64'
+            WHEN age BETWEEN 65 AND 74 THEN '65-74'
+            WHEN age BETWEEN 75 AND 84 THEN '75-84'
+            WHEN age BETWEEN 85 AND 94 THEN '85-94'
+            WHEN age >= 95 THEN '95+'
+            ELSE 'Unknown'
+        END AS age_bucket
+    from {{ ref('dim_customer') }}
+),
+income_buckets AS (
+    SELECT
+        customer_id,
+        CASE 
+            WHEN income < 30000 THEN 'Below 30k'
+            WHEN income BETWEEN 30000 AND 39999 THEN '30k-40k' 
+            WHEN income BETWEEN 40000 AND 59999 THEN '40k-60k'
+            WHEN income BETWEEN 60000 AND 79999 THEN '60k-80k'
+            WHEN income BETWEEN 80000 AND 99999 THEN '80k-100k'
+            WHEN income BETWEEN 100000 AND 120000 THEN '100k-120k'
+            WHEN income >= 120001 THEN '120k+'
+            ELSE 'Out of range'
+        END AS income_bucket
+    from {{ ref('dim_customer') }} 
+),
+customer_tenure AS (
+    SELECT
+        customer_id,
+        CASE
+            WHEN CURRENT_DATE - subscribed_date <= 30 THEN 'New Customer (< 1 month)'
+            WHEN CURRENT_DATE - subscribed_date BETWEEN 31 AND 365 THEN 'Established Customer (1-12 months)'
+            WHEN CURRENT_DATE - subscribed_date BETWEEN 366 AND 730 THEN 'Loyal Customer (1-2 years)Loyal Customer (1-2 years)'
+            WHEN CURRENT_DATE - subscribed_date > 730 THEN 'Long-term Customer (> 2 years)'
+        END AS customer_tenure
+    from {{ ref('dim_customer') }}
+),
+purchase_recency AS (
+    SELECT
+        customer_id,
+        CASE
+            WHEN CURRENT_DATE - DATE(ingested_at) <= 30 THEN 'Recent Buyer (< 1 month)'
+            WHEN CURRENT_DATE - DATE(ingested_at) BETWEEN 31 AND 90 THEN 'Engaged Buyer (1-3 months)'
+            WHEN CURRENT_DATE - DATE(ingested_at) > 90 THEN 'Lapsed Buyer (> 3 months)'
+            ELSE 'Unknown'
+        END AS purchase_recency
+    from {{ ref('fct_customer_transactions') }}
+),
+
+final as (
+    SELECT 
+        ab.age_bucket,
+        ib.income_bucket,
+        ct.customer_tenure,
+        pr.purchase_recency,
+        c.gender,
+        COUNT(*) AS customer_count,
+        ROUND(SUM(CASE WHEN fct.transaction_type = 'completed' THEN 1 ELSE 0 END) * 1.0 / COUNT(fct.transaction_id), 4) AS response_rate,
+        COUNT(CASE WHEN fct.transaction_type = 'completed' THEN 1 END) AS completed_status_transactions,
+        COUNT(fct.transaction_id) AS total_transactions
+    FROM fct_customer_transactions fct
+        LEFT JOIN dim_customer c ON fct.customer_id = c.customer_id
+        LEFT JOIN dim_offer o ON fct.offer_id = o.offer_id
+        LEFT JOIN age_buckets ab ON c.customer_id = ab.customer_id
+        LEFT JOIN income_buckets ib ON c.customer_id = ib.customer_id
+        LEFT JOIN customer_tenure ct ON c.customer_id = ct.customer_id
+        LEFT JOIN purchase_recency pr ON fct.customer_id = pr.customer_id
+    GROUP BY ab.age_bucket, ib.income_bucket, ct.customer_tenure, pr.purchase_recency, c.gender
+    ORDER BY response_rate DESC
+)
+
+select *
+from final

--- a/starbucks_dw/models/reporting/schema.yml
+++ b/starbucks_dw/models/reporting/schema.yml
@@ -1,0 +1,68 @@
+version: 2
+
+models:
+  - name: channels_response_rate
+    description: >
+      Analyzes the impact of offer communication channels and types on customer response rates,
+      incorporating the difficulty rank of the offers to provide further insights.
+    columns:
+      - name: offer_channel
+        description: A list of channels through which the offer was received.
+        data_type: text
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: ['email', 'mobile', 'web', 'social']
+      - name: offer_type
+        description: Type of offer.
+        data_type: text
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: ['discount', 'bogo', 'informational']
+      - name: difficulty_rank
+        description: Minimum spending required to complete an offer.
+        data_type: integer
+        data_tests:
+          - not_null
+      - name: completed_response_rate
+        description: >
+          The rate of transactions where the offer has the status completed relative to the total transactions 
+          for a given channel and offer type.
+        data_type: numeric
+        data_tests:
+          - not_null
+      - name: viewed_response_rate
+        description: >
+          The rate of transactions where the offer has the status viewed relative to the total transactions 
+          for a given channel and offer type.
+        data_type: numeric
+        data_tests:
+          - not_null
+      - name: received_response_rate
+        description: >
+          The rate of transactions where the offer has the status received relative to the total transactions 
+          for a given channel and offer type.
+        data_type: numeric
+        data_tests:
+          - not_null
+      - name: completed_status_transactions
+        description: The total number of transactions with a status of completed for a given channel and offer type.
+        data_type: integer
+        data_tests:
+          - not_null
+      - name: viewed_status_transactions
+        description: The total number of transactions with a status of viewed for a given channel and offer type.
+        data_type: integer
+        data_tests:
+          - not_null
+      - name: received_status_transactions
+        description: The total number of transactions with a status of received for a given channel and offer type.
+        data_type: integer
+        data_tests:
+          - not_null
+      - name: total_transactions
+        description: The total number of transactions for a given channel and offer type.
+        data_type: integer
+        data_tests:
+          - not_null

--- a/starbucks_dw/models/reporting/schema.yml
+++ b/starbucks_dw/models/reporting/schema.yml
@@ -144,7 +144,6 @@ models:
         description: Type of offer.
         data_type: text
         data_tests:
-          - not_null
           - accepted_values:
               values: ['discount', 'bogo', 'informational']
       - name: response_rate

--- a/starbucks_dw/models/reporting/schema.yml
+++ b/starbucks_dw/models/reporting/schema.yml
@@ -66,3 +66,92 @@ models:
         data_type: integer
         data_tests:
           - not_null
+
+  - name: cust_segment_response
+    description: >
+      Segments customers based on demographic information (age, gender), 
+      purchase recency, and customer tenure to analyze response rates to promotional offers.
+    columns:
+      - name: age_bucket
+        description: The age category of the customer.
+        data_type: text
+        data_tests:
+          - not_null
+          - accepted_values:
+              values:
+                - Under 18
+                - 18-24
+                - 25-34
+                - 35-44
+                - 45-54
+                - 55-64
+                - 65-74
+                - 75-84
+                - 85-94
+                - 95+
+      - name: income_bucket
+        description: The income category of the customer.
+        data_type: text
+        data_tests:
+          - not_null
+          - accepted_values:
+              values:
+                - Below 30k
+                - 30k-40k
+                - 40k-60k
+                - 60k-80k
+                - 80k-100k
+                - 100k-120k
+                - 120k+
+      - name: customer_tenure
+        description: How long the customer has been subscribed to.
+        data_type: text
+        data_tests:
+          - not_null
+          - accepted_values:
+              values:
+                - New Customer (< 1 month)
+                - Established Customer (1-12 months)
+                - Loyal Customer (1-2 years)
+                - Long-term Customer (> 2 years)
+      - name: purchase_recency
+        description: The recency of the customer's last purchase.
+        data_type: text
+        data_tests:
+          - not_null
+          - accepted_values:
+              values:
+                - Recent Buyer (< 1 month)
+                - Engaged Buyer (1-3 months)
+                - Lapsed Buyer (> 3 months)
+      - name: gender
+        description: The gender of the customer.
+        data_type: text
+        data_tests:
+          - not_null
+          - accepted_values:
+              values:
+                - M
+                - F
+                - O
+                - N/A
+      - name: customer_count
+        description: The count of customers in each demographic segment.
+        data_type: integer
+        data_tests:
+          - not_null
+      - name: response_rate
+        description: The response rate to promotional offers in the given segment. Only considers transactions with 'completed' status.
+        data_type: numeric
+        data_tests:
+          - not_null
+      - name: completed_status_transactions
+        description: The number of transactions with 'completed' status in each segment.
+        data_type: integer
+        data_tests:
+          - not_null
+      - name: total_transactions
+        description: The total number of transactions in each segment.
+        data_type: integer
+        data_tests:
+          - not_null

--- a/starbucks_dw/models/reporting/schema.yml
+++ b/starbucks_dw/models/reporting/schema.yml
@@ -73,7 +73,7 @@ models:
       purchase recency, and customer tenure to analyze response rates to promotional offers.
     columns:
       - name: age_bucket
-        description: The age category of the customer.
+        description: Age category of the customer.
         data_type: text
         data_tests:
           - not_null
@@ -90,7 +90,7 @@ models:
                 - 85-94
                 - 95+
       - name: income_bucket
-        description: The income category of the customer.
+        description: Income category of the customer.
         data_type: text
         data_tests:
           - not_null
@@ -103,6 +103,17 @@ models:
                 - 80k-100k
                 - 100k-120k
                 - 120k+
+      - name: gender
+        description: Gender of the customer.
+        data_type: text
+        data_tests:
+          - not_null
+          - accepted_values:
+              values:
+                - M
+                - F
+                - O
+                - N/A
       - name: customer_tenure
         description: How long the customer has been subscribed to.
         data_type: text
@@ -115,7 +126,7 @@ models:
                 - Loyal Customer (1-2 years)
                 - Long-term Customer (> 2 years)
       - name: purchase_recency
-        description: The recency of the customer's last purchase.
+        description: Recency of the customer's last purchase.
         data_type: text
         data_tests:
           - not_null
@@ -124,34 +135,30 @@ models:
                 - Recent Buyer (< 1 month)
                 - Engaged Buyer (1-3 months)
                 - Lapsed Buyer (> 3 months)
-      - name: gender
-        description: The gender of the customer.
+      - name: customer_count
+        description: Count of customers in each demographic segment.
+        data_type: integer
+        data_tests:
+          - not_null
+      - name: offer_type
+        description: Type of offer.
         data_type: text
         data_tests:
           - not_null
           - accepted_values:
-              values:
-                - M
-                - F
-                - O
-                - N/A
-      - name: customer_count
-        description: The count of customers in each demographic segment.
-        data_type: integer
-        data_tests:
-          - not_null
+              values: ['discount', 'bogo', 'informational']
       - name: response_rate
-        description: The response rate to promotional offers in the given segment. Only considers transactions with 'completed' status.
+        description: Response rate to promotional offers in the given segment. Only considers transactions with 'completed' status.
         data_type: numeric
         data_tests:
           - not_null
       - name: completed_status_transactions
-        description: The number of transactions with 'completed' status in each segment.
+        description: Number of transactions with 'completed' status in each segment.
         data_type: integer
         data_tests:
           - not_null
       - name: total_transactions
-        description: The total number of transactions in each segment.
+        description: Total number of transactions per segment.
         data_type: integer
         data_tests:
           - not_null

--- a/starbucks_dw/models/staging/schema.yml
+++ b/starbucks_dw/models/staging/schema.yml
@@ -97,3 +97,33 @@ models:
         data_type: timestamp
         data_tests:
           - not_null
+
+  - name: stg_profile
+    description: >
+      Information about the customers that are part of the promotional offers program.
+    columns:
+      - name: a
+        description: "Incremental counter for each row."
+        data_type: integer
+      - name: gender
+        description: "Gender of the customer."
+        data_type: text
+        data_test:
+          - not_null
+      - name: age
+        description: "Age of the customer."
+        data_type: integer
+      - name: customer_id
+        description: "Unique identifier for each customer."
+        data_type: text
+      - name: become_member_date
+        description: "Date when the customer created an app account."
+        data_type: date
+      - name: income
+        description: "Income of the customer."
+        data_type: numeric
+        data_tests:
+          - not_null
+      - name: ingested_at
+        description: "Column with the current timestamp."
+        data_type: timestamp

--- a/starbucks_dw/models/staging/schema.yml
+++ b/starbucks_dw/models/staging/schema.yml
@@ -102,28 +102,40 @@ models:
     description: >
       Information about the customers that are part of the promotional offers program.
     columns:
-      - name: a
-        description: "Incremental counter for each row."
-        data_type: integer
-      - name: gender
-        description: "Gender of the customer."
+      - name: customer_id
+        description: Unique identifier for each customer.
         data_type: text
         data_test:
           - not_null
+          - unique
       - name: age
-        description: "Age of the customer."
+        description: Age of the customer.
         data_type: integer
-      - name: customer_id
-        description: "Unique identifier for each customer."
+        data test:
+          - not_null
+      - name: gender
+        description: Gender of the customer.
         data_type: text
-      - name: become_member_date
-        description: "Date when the customer created an app account."
-        data_type: date
+        data_test:
+          - not_null
+          - accepted_values:
+            values :
+              - M
+              - F
+              - O
+              - N/A
       - name: income
-        description: "Income of the customer."
+        description: Income of the customer.
         data_type: numeric
         data_tests:
           - not_null
+      - name: subscribed_at
+        description: Date when the customer created an app account.
+        data_type: date
+        data_test:
+          - not_null
       - name: ingested_at
-        description: "Column with the current timestamp."
+        description: Column with the current timestamp.
         data_type: timestamp
+        data_test:
+          - not_null

--- a/starbucks_dw/models/staging/schema.yml
+++ b/starbucks_dw/models/staging/schema.yml
@@ -129,7 +129,7 @@ models:
         data_type: numeric
         data_tests:
           - not_null
-      - name: subscribed_at
+      - name: subscribed_date
         description: Date when the customer created an app account.
         data_type: date
         data_test:

--- a/starbucks_dw/models/staging/stg_profile.sql
+++ b/starbucks_dw/models/staging/stg_profile.sql
@@ -15,7 +15,7 @@ with
             to_date(became_member_on::text,'YYYYMMDD') as subscribed_date,
             current_timestamp as ingested_at
         FROM {{ ref('profile') }}
-        WHERE age > 1 and age < 118
+        WHERE age < 118
     )
 
 select *

--- a/starbucks_dw/models/staging/stg_profile.sql
+++ b/starbucks_dw/models/staging/stg_profile.sql
@@ -1,1 +1,22 @@
-/* TO BE IMPLEMENTED BY THE STUDENT */
+{{
+  config(
+    materialized = 'view',
+    )
+}}
+
+
+with
+    transformed_profile as (
+        SELECT
+            id as customer_id,
+            coalesce(age, 0) as age,
+            coalesce(gender,'N/A') as gender,
+            coalesce(income,0) as income,
+            to_date(became_member_on::text,'YYYYMMDD') as became_member_date,
+            current_timestamp as ingested_at
+        FROM {{ ref('profile') }}
+        WHERE age > 1 and age < 118
+    )
+
+select *
+from transformed_profile

--- a/starbucks_dw/models/staging/stg_profile.sql
+++ b/starbucks_dw/models/staging/stg_profile.sql
@@ -12,7 +12,7 @@ with
             coalesce(age, 0) as age,
             coalesce(gender,'N/A') as gender,
             coalesce(income,0) as income,
-            to_date(became_member_on::text,'YYYYMMDD') as subscribed_at,
+            to_date(became_member_on::text,'YYYYMMDD') as subscribed_date,
             current_timestamp as ingested_at
         FROM {{ ref('profile') }}
         WHERE age > 1 and age < 118

--- a/starbucks_dw/models/staging/stg_profile.sql
+++ b/starbucks_dw/models/staging/stg_profile.sql
@@ -12,7 +12,7 @@ with
             coalesce(age, 0) as age,
             coalesce(gender,'N/A') as gender,
             coalesce(income,0) as income,
-            to_date(became_member_on::text,'YYYYMMDD') as became_member_date,
+            to_date(became_member_on::text,'YYYYMMDD') as subscribed_at,
             current_timestamp as ingested_at
         FROM {{ ref('profile') }}
         WHERE age > 1 and age < 118

--- a/starbucks_dw/package-lock.yml
+++ b/starbucks_dw/package-lock.yml
@@ -1,4 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 1.3.0
-sha1_hash: 226ae69cdfbc9367e2aa2c472b01f99dbce11de0
+  - package: calogica/dbt_date
+    version: 0.10.1
+sha1_hash: 5fc236b054feee3cb13f56236475b3cb64d3203d

--- a/starbucks_dw/packages.yml
+++ b/starbucks_dw/packages.yml
@@ -1,3 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 1.3.0
+
+  - package: calogica/dbt_date
+    version: 0.10.1

--- a/starbucks_dw/seeds/schema.yaml
+++ b/starbucks_dw/seeds/schema.yaml
@@ -34,15 +34,12 @@ seeds:
       Information about the customers that are part of the promotional offers program.
     config:
       column_types:
-        a: integer
         gender: text
         age: integer
         id: text
         become_member_on: integer
         income: numeric
     columns:
-      - name: a
-        description: Incremental counter for each row.
       - name: gender
         description: Gender of the customer.
       - name: age


### PR DESCRIPTION
I was going to use [width_bucket (of dbt_utils)](https://github.com/dbt-labs/dbt-utils/tree/1.3.0/#width_bucket-source) to create the age_buckets and income_buckets in cust_segment_response, but I chose not to do that. I ended up with numbers, which are not intuitive since I can't see the ranges they are considering. As I needed to add aliases, I found it simpler to create the buckets the way they are now.
